### PR TITLE
Allow completion of dot directories

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -25,6 +25,9 @@ else
 fi
 unset CASE_SENSITIVE HYPHEN_INSENSITIVE
 
+# Complete . and .. special directories
+zstyle ':completion:*' special-dirs true
+
 zstyle ':completion:*' list-colors ''
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#) ([0-9a-z-]#)*=01;34=0=01'
 


### PR DESCRIPTION
Fixes #3775, fixes #6543.

This makes zsh treat `.` and `..` as directories to be completed. That means it will insert a slash (`/`) when these directories are provided in the command line.