### PR TITLE
fix(updater): disable `nounset` to avoid warnings

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env zsh
+set +u # disable nounset
 
 local ret=0 # exit code
 


### PR DESCRIPTION
Fixes #11838